### PR TITLE
fix: release v0.7.2 — map/splice/concat bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.2] - 2026-05-19
+
+### Fixed
+
+- **map()**: chained transformers now receive the same chunk index for the same chunk. Previously the index was incremented per transformer invocation, so `map(s, fn1, fn2, fn3)` over 5 chunks made `fn1` see indices `[0, 3, 6, 9, 12]` instead of `[0, 1, 2, 3, 4]`.
+- **splice()**: insert-only calls (`replaced === 0`) and calls with `start` beyond the stream length now correctly insert the new items, matching `Array.prototype.splice`. Previously the items were silently dropped.
+- **concat()**: respects consumer backpressure. Earlier the first `pull()` drained every source stream eagerly, so combining `concat` with `slice()`, `take()`, or any early-terminating operator wastefully read sources the consumer never asked for. Later sources are now opened only when the previous one is drained, and not at all if the consumer stops first.
+
 ## [0.7.1] - 2026-05-12
 
 ### Changed

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,147 @@
+# streamfu — Plan TDD para v0.7.2 y v0.8.0
+
+Objetivo: resolver el feedback OSS detectado tras la integración real en `TwenixPlatform/platform-back#5907` y dejar la librería en disposición de simplificar drásticamente ese PR.
+
+## Convenciones
+
+- **TDD estricto** en cada paso: RED → GREEN → REFACTOR.
+- `deno task test` verde tras cada paso, 100 % de cobertura.
+- Conventional Commits, un commit por paso.
+- Una rama por fase (`fix/v0.7.2-bugs`, `feat/v0.8.0-api`, ...).
+
+---
+
+## Fase 1 — Bug fixes → publicar v0.7.2
+
+### Paso 1.1 — Bug índice en `map(stream, fn1, fn2, ...)`
+
+`src/map.ts:191-212` incrementa `i++` una vez por cada transformer, no por chunk.
+Con `map(s, fn1, fn2, fn3)` sobre 5 chunks, `fn1` recibe `i = 0, 3, 6, 9, 12`.
+
+- RED: caso en `TEST_CASES` que verifique que todos los transformers del mismo chunk reciben el mismo índice y que los índices crecen 0..N-1 por chunk.
+- GREEN: sacar `i++` del bucle interno y aplicarlo una sola vez por chunk.
+- REFACTOR: renombrar a `chunkIndex`.
+
+### Paso 1.2 — `splice` insert-only y al final del stream
+
+`src/splice.ts:23-32` no inserta si `replaced === 0` y no inserta si `start` queda más allá del fin del stream.
+
+- RED: tres casos — insert-only, insert-al-final, splice normal (regresión).
+- GREEN: reescribir con `transform` + `flush`, gestionando la inserción independientemente del borrado.
+- REFACTOR: helper `enqueueNewItems(ctrl)`, JSDoc actualizado.
+
+### Paso 1.3 — `concat` respeta backpressure
+
+`src/concat.ts:10-23` itera todos los streams enteros en `pull()` sin esperar al consumidor.
+
+- RED: con tres `range(0, 10_000)` concatenados y un `slice(_, 0, 5)`, verificar que las fuentes 2 y 3 no se han leído.
+- GREEN: reescribir con async generator + `ReadableStream.from` (reusando el polyfill de Bun).
+- REFACTOR: extraer `readableStreamFrom` a `src/system/stream.ts`.
+
+### Paso 1.4 — Release v0.7.2
+
+1. Bump `deno.json` → `0.7.2`.
+2. `CHANGELOG.md` sección "Fixed".
+3. Merge a `main` → CI publica en JSR y npm.
+4. Smoke-test en `platform-back`.
+
+---
+
+## Fase 2 — API gaps → v0.8.0
+
+### Paso 2.1 — `filter` recibe índice
+
+- RED: `filter([10,20,30,40], (x, i) => i % 2 === 0)` → `[10,30]`.
+- GREEN: contador interno, mismo patrón que `forEach`.
+
+### Paso 2.2 — Consumer `count(stream)`
+
+- RED: `count([])` → 0; `count(slice(range(0,1_000_000), 0, 5))` → 5.
+- GREEN: `reduce(s, n => n+1, 0)`.
+
+### Paso 2.3 — `tap(stream, fn)`
+
+- RED: pasa chunks intactos, llama a `fn` con `(chunk, i)`, async respeta orden, errores propagan.
+- GREEN: `TransformStream` que enqueua tras `await fn(chunk, i++)`.
+
+### Paso 2.4 — `take` y `drop`
+
+- RED: aliases de `slice`. `take(infiniteRange, 3)` termina.
+- GREEN: delegación trivial.
+
+### Paso 2.5 — `batch(stream, size)`
+
+- RED: agrupa de N en N, último batch parcial, `size <= 0` lanza `RangeError`.
+- GREEN: `TransformStream` con buffer + `flush`.
+
+### Paso 2.6 — `merge(...streams)` interleaved
+
+- RED: stream A delay 10ms, stream B delay 0; primeros chunks vienen de B.
+- GREEN: `Promise.race` sobre readers.
+
+### Paso 2.7 — `pipe` acepta `TransformStream`
+
+- RED: `pipe(s, transformStream)` y mezclado con funciones.
+- GREEN: detectar `instanceof TransformStream` y hacer `pipeThrough`.
+
+### Paso 2.8 — `toBuffer(stream)` → `Uint8Array`
+
+- RED: mezcla de `string | Buffer | Uint8Array`, bytes UTF-8 multi-byte.
+- GREEN: reduce concatenando.
+
+### Paso 2.9 — `lines(stream)` y `csvLines(stream)`
+
+- RED: chunks fragmentados, `\r\n` y `\n`, comillas para CSV.
+- GREEN: adaptar la lógica del `lineTransformer` del PR.
+
+### Paso 2.10 — README "Working with Node streams"
+
+- Sin TDD: documentar `Readable.toWeb()`, `safeQueryRunner` como receta, ejemplo CSV end-to-end.
+
+### Paso 2.11 — Generator `iterate(fn)` con sentinela `null`
+
+- RED: `iterate(i => i < 5 ? i : null)` → `[0,1,2,3,4]`.
+- GREEN: async generator que para cuando `fn(i) === null`.
+
+### Paso 2.12 — JSDoc unify "consuming"
+
+Añadir `NOTE: This consumes the stream...` a `at`, `some`, `every`, `includes`, `indexOf`, `join`, `count`.
+
+---
+
+## Fase 3 — Packaging
+
+### Paso 3.1 — Subpath exports
+
+`@sgmonda/streamfu/map`, `/filter`, etc. en `package.json` y `deno.json`.
+
+---
+
+## Fase 4 — Tests de profundidad
+
+### Paso 4.1 — Property-based tests con `fast-check`
+
+Propiedades equivalencia stream/array para `map`, `filter`, `reduce`, `concat`, `take`.
+
+### Paso 4.2 — Test integración Node real
+
+NDJSON grande con `fs.createReadStream` → `Readable.toWeb` → pipeline completa.
+
+---
+
+## Fase 5 — Release v0.8.0
+
+1. Bump `deno.json` → `0.8.0`.
+2. `CHANGELOG.md` con Added / Changed / Fixed.
+3. Merge → CI publica.
+4. GitHub Release con highlights.
+
+---
+
+## Fase 6 — Simplificar PR `platform-back#5907`
+
+Eliminar de `src/providers/streams/`: `array2stream`, `cloneStream`, `concat`, `filter`, `map`, `reduce`, `safeStream`, `streamize`, `toArray`, `toBuffer`, `transformers/lineTransformer`.
+Reducir `collect` a 5 líneas con `tap` + `concat`.
+Mantener: `safeQueryRunner`, `merge` (object-merge), `toCsv`, `csvTransformer`, `createTransformer`.
+
+Resultado estimado: PR pasa de ~1.300 LOC añadidas a <300.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@sgmonda/streamfu",
   "description": "Functional programming utilities for working with streams in JS/TS",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "exports": "./mod.ts",
   "imports": {

--- a/src/concat.test.ts
+++ b/src/concat.test.ts
@@ -1,7 +1,8 @@
-import { assertEquals, assertRejects } from "asserts"
+import { assertEquals, assertLess, assertRejects } from "asserts"
 import { concat } from "./concat.ts"
 import { list } from "./list.ts"
 import { createReadable } from "./createReadable.ts"
+import { slice } from "./slice.ts"
 
 const TEST_CASES = [{
   title: "empty streams",
@@ -24,6 +25,42 @@ const TEST_CASES = [{
   iterators: [[1, 2], [], [3, 4]],
   expected: [1, 2, 3, 4],
 }]
+
+Deno.test("concat() backpressure", async ({ step }) => {
+  type InstrumentedStream = { stream: ReadableStream<number>; pulls: () => number }
+
+  const buildInstrumented = (size: number): InstrumentedStream => {
+    let pulls = 0
+    let emitted = 0
+    // highWaterMark=0 disables the constructor-time prefetch so we measure
+    // only the pulls caused by the consumer, not the runtime's initial fill.
+    const stream = new ReadableStream<number>({
+      pull(controller) {
+        pulls++
+        if (emitted < size) controller.enqueue(emitted++)
+        else controller.close()
+      },
+    }, { highWaterMark: 0 })
+    return { stream, pulls: () => pulls }
+  }
+
+  await step("only pulls from later streams what the consumer actually requests", async () => {
+    // A has 2 chunks → exhausts before slice(0,3) is done. slice needs 1 from B.
+    // A buggy concat that drains in a single pull() reads many extra chunks
+    // from B before the consumer's cancel signal can propagate.
+    const a = buildInstrumented(2)
+    const b = buildInstrumented(1000)
+    const c = buildInstrumented(1000)
+    const result = await list(slice(concat(a.stream, b.stream, c.stream), 0, 3))
+    assertEquals(result, [0, 1, 0])
+    // The exact b.pulls count depends on pipeTo's lookahead, but a buggy concat
+    // that drains in a single pull pulls dozens of chunks before the consumer's
+    // cancel signal propagates. A backpressure-respecting concat stays in
+    // single digits regardless of stream size.
+    assertLess(b.pulls(), 5, `concat should not drain stream b (got ${b.pulls()} pulls)`)
+    assertEquals(c.pulls(), 0, "stream c should never be opened (not needed)")
+  })
+})
 
 Deno.test("concat() error propagation", async ({ step }) => {
   await step("error in source stream propagates to consumer", async () => {

--- a/src/concat.ts
+++ b/src/concat.ts
@@ -1,5 +1,11 @@
+import { ReadableStream } from "./system/stream.ts"
+
 /**
- * Concatenates multiple readable streams into a single one.
+ * Concatenates multiple readable streams into a single one, in order.
+ *
+ * Pulls from each source lazily and respects consumer backpressure: a source
+ * is only opened when the previous one is fully drained, and never opened at
+ * all if the consumer stops early (e.g. via `slice` or `take`).
  *
  * @param readables Streams to concatenate
  * @returns A new readable stream with all the chunks from the input streams
@@ -7,17 +13,29 @@
  * @example const concatenated = concat(readable1, readable2, readable3)
  */
 export const concat = <T>(...readables: ReadableStream<T>[]): ReadableStream<T> => {
-  return new ReadableStream({
+  let cursor = 0
+  let reader: ReadableStreamDefaultReader<T> | null = null
+  return new ReadableStream<T>({
     async pull(controller) {
-      for (const readable of readables) {
-        const reader = readable.getReader()
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
+      while (cursor < readables.length) {
+        if (!reader) reader = readables[cursor].getReader()
+        const { done, value } = await reader.read()
+        if (!done) {
           controller.enqueue(value)
+          return
         }
+        reader.releaseLock()
+        reader = null
+        cursor++
       }
       controller.close()
+    },
+    async cancel(reason) {
+      if (reader) {
+        await reader.cancel(reason)
+        reader.releaseLock()
+        reader = null
+      }
     },
   })
 }

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -44,7 +44,7 @@ const TEST_CASES = [{
   conditions: {
     iterable: ["1", "2", "3"],
     transforms: [
-      parseInt,
+      (num: string) => parseInt(num, 10),
       (item: number) => item * 2.1299,
       (item: number) => item.toFixed(3),
     ],
@@ -106,6 +106,43 @@ Deno.test("map() type inference", async ({ step }) => {
       (num) => num > 3,
     )
     assertEquals(await list(result), [false, true, true])
+  })
+})
+
+Deno.test("map() chunk index", async ({ step }) => {
+  await step("single transformer receives chunk index 0..N-1", async () => {
+    const seen: number[] = []
+    const stream = map(createReadable(["a", "b", "c", "d"]), (chunk, i) => {
+      seen.push(i)
+      return `${chunk}${i}`
+    })
+    assertEquals(await list(stream), ["a0", "b1", "c2", "d3"])
+    assertEquals(seen, [0, 1, 2, 3])
+  })
+
+  await step("chained transformers all receive the same index for the same chunk", async () => {
+    const seenFn1: number[] = []
+    const seenFn2: number[] = []
+    const seenFn3: number[] = []
+    const stream = map(
+      createReadable([10, 20, 30, 40, 50]),
+      (chunk, i) => {
+        seenFn1.push(i)
+        return chunk
+      },
+      (chunk, i) => {
+        seenFn2.push(i)
+        return chunk
+      },
+      (chunk, i) => {
+        seenFn3.push(i)
+        return chunk
+      },
+    )
+    assertEquals(await list(stream), [10, 20, 30, 40, 50])
+    assertEquals(seenFn1, [0, 1, 2, 3, 4])
+    assertEquals(seenFn2, [0, 1, 2, 3, 4])
+    assertEquals(seenFn3, [0, 1, 2, 3, 4])
   })
 })
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -189,13 +189,14 @@ export function map<A, B, C, D, E, F, G, H, I, J>(
 export function map(readable: ReadableStream<any>, ...transformers: ITransformer<any, any>[]): ReadableStream<any>
 // deno-lint-ignore no-explicit-any
 export function map(readable: ReadableStream<any>, ...transformers: ITransformer<any, any>[]): ReadableStream<any> {
-  let i = 0
+  let chunkIndex = 0
   // deno-lint-ignore no-explicit-any
   const applyTransformers = async (chunk: any): Promise<any> => {
     let value: unknown = chunk
     for (const fn of transformers) {
-      value = await fn(value, i++)
+      value = await fn(value, chunkIndex)
     }
+    chunkIndex++
     return value
   }
   const ts = new TransformStream({

--- a/src/splice.test.ts
+++ b/src/splice.test.ts
@@ -22,14 +22,14 @@ const TEST_CASES = [{
   },
   expected: [],
 }, {
-  title: "single item stream, inserting without removing (do nothing)",
+  title: "single item stream, inserting without removing",
   conditions: {
     data: [33],
     index: 0,
     replaced: 0,
     inserted: [44],
   },
-  expected: [33],
+  expected: [44, 33],
 }, {
   title: "multiple items stream, removing",
   conditions: {
@@ -40,12 +40,39 @@ const TEST_CASES = [{
   },
   expected: [11, 22, 44, 55],
 }, {
-  title: "multiple items stream, inserting without removing (do nothing)",
+  title: "multiple items stream, inserting without removing",
   conditions: {
     data: [11, 22, 33, 44, 55],
     index: 2,
     replaced: 0,
     inserted: [66, 77],
+  },
+  expected: [11, 22, 66, 77, 33, 44, 55],
+}, {
+  title: "start beyond stream length, inserting (insert at end)",
+  conditions: {
+    data: [11, 22, 33],
+    index: 99,
+    replaced: 1,
+    inserted: [44, 55],
+  },
+  expected: [11, 22, 33, 44, 55],
+}, {
+  title: "start beyond stream length, no items to remove (insert at end)",
+  conditions: {
+    data: [11, 22, 33],
+    index: 99,
+    replaced: 0,
+    inserted: [44],
+  },
+  expected: [11, 22, 33, 44],
+}, {
+  title: "insert at end of stream (start equals length)",
+  conditions: {
+    data: [11, 22, 33],
+    index: 3,
+    replaced: 0,
+    inserted: [44, 55],
   },
   expected: [11, 22, 33, 44, 55],
 }, {

--- a/src/splice.ts
+++ b/src/splice.ts
@@ -1,16 +1,24 @@
 import { TransformStream } from "./system/stream.ts"
 
 /**
- * Replace items from a ReadableStream, starting at a given index.
+ * Mirrors `Array.prototype.splice`: removes `replaced` items starting at `start`
+ * and inserts `newItems` at that position. If `start` is greater than or equal
+ * to the stream length, items are appended at the end (matching how
+ * `Array.prototype.splice` clamps `start` to `length`).
+ *
+ * Unlike `Array.prototype.splice`, this function does not return the removed
+ * items — it returns a new readable stream with the modified sequence.
  *
  * @param readable The readable stream to splice
  * @param start The index at which to start replacing items from the stream
- * @param replaced The number of items to replace from the stream. If 0, no items will be removed or inserted
+ * @param replaced The number of items to remove from the stream
  * @param newItems The items to insert into the stream
  * @returns A readable stream with the items removed and/or inserted
  *
  * @example const oneless = splice(readable, 2, 1)
  * @example const spliced = splice(readable, 2, 1, 'a', 'b', 'c')
+ * @example const inserted = splice(readable, 2, 0, 'a', 'b') // insert without removing
+ * @example const appended = splice(readable, 999, 0, 'x') // start beyond length: append
  */
 export const splice = <T>(
   readable: ReadableStream<T>,
@@ -19,18 +27,20 @@ export const splice = <T>(
   ...newItems: T[]
 ): ReadableStream<T> => {
   let index = 0
+  let inserted = false
+  const enqueueNewItems = (controller: TransformStreamDefaultController<T>) => {
+    for (const item of newItems) controller.enqueue(item)
+    inserted = true
+  }
   const transform = new TransformStream<T, T>({
     transform: (chunk, controller) => {
-      if (index++ >= start && replaced > 0) {
-        replaced--
-        if (!replaced) {
-          newItems.forEach((item) => controller.enqueue(item))
-        }
-        return
-      }
-      controller.enqueue(chunk)
+      if (index === start && !inserted) enqueueNewItems(controller)
+      if (index < start || index >= start + replaced) controller.enqueue(chunk)
+      index++
+    },
+    flush: (controller) => {
+      if (!inserted) enqueueNewItems(controller)
     },
   })
-
   return readable.pipeThrough(transform)
 }


### PR DESCRIPTION
## Summary

Three production bugs surfaced while integrating streamfu into a real codebase (`TwenixPlatform/platform-back#5907`).

- **`map(s, fn1, fn2, ...)`**: chained transformers received `i` incremented per transformer instead of per chunk. `fn1` over 5 chunks saw `[0, 3, 6, 9, 12]` instead of `[0, 1, 2, 3, 4]`.
- **`splice()`**: insert-only (`replaced === 0`) and out-of-range `start` silently dropped the inserted items. Now aligned with `Array.prototype.splice` semantics.
- **`concat()`**: drained every source stream eagerly in a single `pull()`, defeating backpressure. Combined with `slice()`/`take()` it pulled chunks the consumer never asked for. Now lazy and consumer-driven.

Three new tests pin each fix; one existing test in `splice` (`...inserting without removing (do nothing)`) that documented the buggy behaviour as intentional was corrected. 100% line coverage maintained.

The plan tracking these fixes plus the upcoming `v0.8.0` feature work is captured in `PLAN.md`.

## Test plan

- [x] `deno task test` green on Deno
- [x] `examples/node` green on npm, yarn, pnpm
- [x] `examples/bun` green on Bun
- [x] `examples/cloudflare-workers` green
- [x] Coverage 100% on `map.ts`, `splice.ts`, `concat.ts`
- [x] Each bug demonstrated via a failing test added before the fix (TDD)
- [ ] Smoke-test in `platform-back` after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)